### PR TITLE
#20 [fix] 카테고리 Optional 객체 예외 처리 및 리팩토링

### DIFF
--- a/cds-server/src/main/java/org/sopt/cdsserver/category/service/CategoryService.java
+++ b/cds-server/src/main/java/org/sopt/cdsserver/category/service/CategoryService.java
@@ -27,7 +27,7 @@ public class CategoryService {
 
     public List<ProductHomeListResponse> getHomeCategoryList(final int categoryId){
         Category category = categoryJpaRepository.findById(categoryId).orElseThrow(
-                () -> new NotFoundException(ErrorType.CATEGORY_NOT_FOUND_EXCEPTION)
+                () -> new NotFoundException(ErrorType.DATA_NOT_FOUND_EXCEPTION)
         );
         return productService.getProductHomeListByCategory(category);
     }

--- a/cds-server/src/main/java/org/sopt/cdsserver/category/service/CategoryService.java
+++ b/cds-server/src/main/java/org/sopt/cdsserver/category/service/CategoryService.java
@@ -26,7 +26,9 @@ public class CategoryService {
     }
 
     public List<ProductHomeListResponse> getHomeCategoryList(final int categoryId){
-        Category category = categoryJpaRepository.findById(categoryId).get();
+        Category category = categoryJpaRepository.findById(categoryId).orElseThrow(
+                () -> new NotFoundException(ErrorType.CATEGORY_NOT_FOUND_EXCEPTION)
+        );
         return productService.getProductHomeListByCategory(category);
     }
 }

--- a/cds-server/src/main/java/org/sopt/cdsserver/common/config/JpaAuditingConfig.java
+++ b/cds-server/src/main/java/org/sopt/cdsserver/common/config/JpaAuditingConfig.java
@@ -1,4 +1,0 @@
-package org.sopt.cdsserver.common.config;
-
-public class JpaAuditingConfig {
-}

--- a/cds-server/src/main/java/org/sopt/cdsserver/common/exception/enums/ErrorType.java
+++ b/cds-server/src/main/java/org/sopt/cdsserver/common/exception/enums/ErrorType.java
@@ -13,6 +13,8 @@ public enum ErrorType {
     PRODUCT_NOT_IN_CATEGORY_EXCEPTION(HttpStatus.NOT_FOUND, "카테고리에 해당하는 상품이 없습니다."),
     CATEGORY_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
 
+    DATA_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "데이터가 존재하지 않습니다."),
+
     INTERNAL_SERVER_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
     private final HttpStatus httpStatus;
     private final String message;

--- a/cds-server/src/main/java/org/sopt/cdsserver/heart/controller/dto/response/HeartPutResponse.java
+++ b/cds-server/src/main/java/org/sopt/cdsserver/heart/controller/dto/response/HeartPutResponse.java
@@ -2,8 +2,6 @@ package org.sopt.cdsserver.heart.controller.dto.response;
 
 import org.sopt.cdsserver.heart.domain.Heart;
 
-import java.util.Optional;
-
 public record HeartPutResponse(
         boolean isMade
 ) {

--- a/cds-server/src/main/java/org/sopt/cdsserver/heart/service/HeartService.java
+++ b/cds-server/src/main/java/org/sopt/cdsserver/heart/service/HeartService.java
@@ -26,7 +26,6 @@ public class HeartService {
         Optional<Heart> existingHeart = heartRepository.findByMemberIdAndProductId(memberId, productId);
 
         return existingHeart.map(heart -> {
-
             deleteHeart(heart);
             return HeartPutResponse.of(null);
         }).orElseGet(() -> {


### PR DESCRIPTION
## ✒️ 관련 ISSUE NUM
- close #20 

## 🔑 KEY CHANGES
카테고리 Optional 객체 예외 처리 및 리팩토링

클라이언트 측 버그 대응입니다! 
Optional에서 .get을 사용하면 NoSuchElement예외가 발생합니다! 그래서 항상 orElseThrow를 해주어야하는데요!
![image](https://github.com/DO-SOPT-CDS-APP-2/CDS-APP-2-SERVER/assets/79795051/3bdcd5b5-41ce-4c41-873c-c4ea366c3e9a)

이렇게 예외가 발생하는 상황에서 orElseThrow문 사용해서 카테고리가 존재하지 않을경우
![image](https://github.com/DO-SOPT-CDS-APP-2/CDS-APP-2-SERVER/assets/79795051/104f2844-adfc-4fe1-90bb-579097592144)

위와 같이 404를 반환하도록 에러 처리해놓았습니다!
## 📢 TO REVIEWER
항상 항상 Optional에서는 `.get` 사용 지양해주세요~~!! 
데이터 어디로 다 날라갔나..
