### PR TITLE
#24 [fix] 동시 요청 버그 해결

### DIFF
--- a/cds-server/src/main/java/org/sopt/cdsserver/common/exception/enums/ErrorType.java
+++ b/cds-server/src/main/java/org/sopt/cdsserver/common/exception/enums/ErrorType.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorType {
     PRODUCT_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 상품을 찾을 수 없습니다."),
     MEMBER_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 멤버를 찾을 수 없습니다"),
-
+    HEART_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 상품에 좋아요가 없습니다."),
     PRODUCT_NOT_IN_CATEGORY_EXCEPTION(HttpStatus.NOT_FOUND, "카테고리에 해당하는 상품이 없습니다."),
     CATEGORY_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
 

--- a/cds-server/src/main/java/org/sopt/cdsserver/heart/service/HeartService.java
+++ b/cds-server/src/main/java/org/sopt/cdsserver/heart/service/HeartService.java
@@ -1,6 +1,8 @@
 package org.sopt.cdsserver.heart.service;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.cdsserver.common.exception.enums.ErrorType;
+import org.sopt.cdsserver.common.exception.model.NotFoundException;
 import org.sopt.cdsserver.heart.controller.dto.response.HeartPutResponse;
 import org.sopt.cdsserver.heart.domain.Heart;
 import org.sopt.cdsserver.heart.repository.HeartRepository;
@@ -8,45 +10,42 @@ import org.sopt.cdsserver.member.domain.Member;
 import org.sopt.cdsserver.member.service.MemberService;
 import org.sopt.cdsserver.product.domain.Product;
 import org.sopt.cdsserver.product.service.ProductService;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class HeartService {
     private final HeartRepository heartRepository;
     private final MemberService memberService;
     private final ProductService productService;
 
     public HeartPutResponse toggleHeart(Long memberId, Long productId) {
-
-        Optional<Heart> existingHeart = heartRepository.findByMemberIdAndProductId(memberId, productId);
-
-        return existingHeart.map(heart -> {
-            deleteHeart(heart);
-            return HeartPutResponse.of(null);
-        }).orElseGet(() -> {
+        try {
             Heart newHeart = createHeart(memberId, productId);
             return HeartPutResponse.of(newHeart);
-        });
-
+        } catch (DataIntegrityViolationException e)  {
+            deleteHeart(memberId, productId);
+            return HeartPutResponse.of(null);
+        }
     }
 
-    private void deleteHeart(Heart heart) {
+    public void deleteHeart(Long memberId, Long productId) {
+        Heart heart = heartRepository.findByMemberIdAndProductId(memberId, productId).orElseThrow(
+                () -> new NotFoundException(ErrorType.HEART_NOT_FOUND_EXCEPTION)
+        );
         heartRepository.delete(heart);
-
     }
 
     private Heart createHeart(Long memberId, Long productId) {
         Member member = memberService.getMemberById(memberId);
         Product product = productService.getProductById(productId);
         Heart newHeart = Heart.create(member, product);
-        heartRepository.save(newHeart);
+        heartRepository.saveAndFlush(newHeart);
         return newHeart;
     }
 
-
+    public HeartPutResponse create(Long memberId, Long productId) {
+        return HeartPutResponse.of(createHeart(memberId, productId));
+    }
 }


### PR DESCRIPTION
## ✒️ 관련 ISSUE NUM
- close #24 

## 🔑 KEY CHANGES
아래는 좋아요 로직과 버그 발생 경위입니다!
![image](https://github.com/DO-SOPT-CDS-APP-2/CDS-APP-2-SERVER/assets/79795051/b91ff10d-d405-4c52-94b0-73cbd4f233a2)
이렇게 되면 이후에 삭제를 하기 위해 select heart를 했을 때, 2개의 좋아요를 반환하게 되어 `NoUniqueResultException`이 발생하게 됩니다.
초기에 트랜잭션에 락을 거는 방법으로 해결하려고 했었는데, 3번의 select문 후에 발생하는 insert문을 다른 트랜잭션으로 인식합니다. 그래서 락을 거는 방법으로 해결하지 않고, 다음과 같은 방법으로 해결했습니다!
- DB Heart 생성 DDL에 unique key를 설정하여 같은 product id와 member id로는 하나의 heart만 가지게 한다.
```sql
create table if not exists sopt.heart
(
    id         bigint auto_increment
        primary key,
    member_id  bigint null,
    product_id bigint null,
    constraint uk_product_member
        unique (member_id, product_id), # 이렇게 unique key 제약 조건을 추가해줍니다!
    constraint FKiabfybq4nkjndkwptwe38yuj7
        foreign key (product_id) references sopt.product (id),
    constraint FKiqbtbunbl2h0r928gnlg7ncta
        foreign key (member_id) references sopt.member (id)
);

```
- 만일 추가적인 요청이 들어오면 DataIntegrityViolation 예외가 발생합니다.
- 아래와 같이 `try{} ~ catch{}` 문을 통해 예외가 걸릴 경우 하트를 삭제합니다.
```java
        try {
            Heart newHeart = createHeart(memberId, productId);
            return HeartPutResponse.of(newHeart);
        } catch (DataIntegrityViolationException e)  {
            deleteHeart(memberId, productId);
            return HeartPutResponse.of(null);
        }
```
- 그래서 두개의 요청이 동시에 들어올 경우 첫 번째 요청은 정상적으로 하트를 생성하고 두번째 요청은 삭제하게끔 구현했습니다!

## 📢 TO REVIEWER
커밋 메시지에 오타가 있네요 하핫..
그리고 동시성 이슈를 락으로 해결하는 방법은 블로그를 작성해보도록 하겠습니다!

